### PR TITLE
Respect DOCKER_HOST

### DIFF
--- a/steps/container.py
+++ b/steps/container.py
@@ -34,7 +34,8 @@ import time
 try:
     d = docker.Client(version="1.22")
 except:
-    d = docker.APIClient(version="1.22")
+    base_url=os.getenv('DOCKER_HOST', 'unix://var/run/docker.sock')
+    d = docker.APIClient(base_url=base_url, version="1.22")
 
 
 class ExecException(Exception):

--- a/steps/image_steps.py
+++ b/steps/image_steps.py
@@ -1,5 +1,6 @@
 import docker
 import logging
+import os
 
 
 from behave import then
@@ -8,7 +9,8 @@ from behave import then
 try:
     DOCKER_CLIENT = docker.Client(version="1.22")
 except:
-    DOCKER_CLIENT = docker.APIClient(version="1.22")
+    base_url=os.getenv('DOCKER_HOST', 'unix://var/run/docker.sock')
+    DOCKER_CLIENT = docker.APIClient(base_url=base_url, version="1.22")
 
 LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 logging.basicConfig(format=LOG_FORMAT)


### PR DESCRIPTION
Get socket from `DOCKER_HOST` env variable to support podman.

Usage example:
```
podman system service -t3600 &
export DOCKER_HOST="unix:/run/user/$(id -u)/podman/podman.sock"
cekit test --image quay.io/quarkus/ubi-quarkus-mandrel:20.1.0.4.Final-java11 --overrides-file quarkus-mandrel.yaml --overrides "{'version': '20.1.0.4.Final-java11', 'modules': {'install': [{'name':'mandrel', 'version': '20.1.0.4.Final-java11'}]}}" behave --steps-url https://github.com/zakkak/behave-test-steps --name "Check that native-image still mentions GraalVM"
```